### PR TITLE
Use fork of networking-odl for stable/kilo.

### DIFF
--- a/puppet/templates/compute.local.conf.erb
+++ b/puppet/templates/compute.local.conf.erb
@@ -1,5 +1,6 @@
 [[local|localrc]]
-enable_plugin networking-odl https://github.com/stackforge/networking-odl
+#enable_plugin networking-odl https://github.com/stackforge/networking-odl
+enable_plugin networking-odl https://github.com/flavio-fernandes/networking-odl stable/kilo
 
 LOGFILE=stack.sh.log
 LOG_COLOR=False

--- a/puppet/templates/control.local.conf.erb
+++ b/puppet/templates/control.local.conf.erb
@@ -1,7 +1,7 @@
 [[local|localrc]]
-enable_plugin networking-odl https://github.com/stackforge/networking-odl
+#enable_plugin networking-odl https://github.com/stackforge/networking-odl
 #enable_plugin networking-odl /vagrant/x/networking-odl.git plugin
-#enable_plugin networking-odl https://github.com/flavio-fernandes/networking-odl odlDevel
+enable_plugin networking-odl https://github.com/flavio-fernandes/networking-odl stable/kilo
 
 LOGFILE=stack.sh.log
 SCREEN_LOGDIR=/opt/stack/data/log


### PR DESCRIPTION
The stable/kilo branch of networking-odl doesn't
have a fix needed for Security Groups. This patch
uses a fork of networking-odl's stable/kilo branch
that includes this fix.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
